### PR TITLE
add option: remote

### DIFF
--- a/GitAutoDeploy.conf.json.example
+++ b/GitAutoDeploy.conf.json.example
@@ -10,6 +10,7 @@
 	[{
 		"url": "https://github.com/olipo186/Git-Auto-Deploy.git",
 		"branch": "master",
+		"remote": "origin",
 		"path": "~/repositories/Git-Auto-Deploy",
 		"deploy": "echo deploying"
 	},

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -60,14 +60,15 @@ class GitWrapper():
         from subprocess import call
 
         branch = ('branch' in repo_config) and repo_config['branch'] or 'master'
+        remote = ('remote' in repo_config) and repo_config['remote'] or 'origin'
 
         print "Post push request received"
         print 'Updating ' + repo_config['path']
 
         cmd = 'cd "' + repo_config['path'] + '"' \
               '&& unset GIT_DIR ' + \
-              '&& git fetch origin ' + \
-              '&& git reset --hard origin/' + branch + ' ' + \
+              '&& git fetch ' + remote + \
+              '&& git reset --hard ' + remote + '/' + branch + ' ' + \
               '&& git submodule init ' + \
               '&& git submodule update'
 


### PR DESCRIPTION
Sometimes it is useful if you have forked repo and so on..
Default value is 'origin'
Here is where to change it.
Example:
```
	[{
		"url": "https://github.com/olipo186/Git-Auto-Deploy.git",
		"branch": "master",
		"remote": "origin",
		"path": "~/repositories/Git-Auto-Deploy",
		"deploy": "echo deploying"
	},
```