### PR TITLE
Clone with branch

### DIFF
--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -438,13 +438,10 @@ class GitAutoDeploy(object):
             if not os.path.isdir(repo_config['path']):
 
                 print "Directory %s not found" % repo_config['path']
-                if 'branch' in repo_config:
-                    GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
-                else:
-                    GitWrapper.clone(url=repo_config['url'], branch=None, path=repo_config['path'])
+                GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'] if 'branch' in repo_config else None, path=repo_config['path'])
 
                 if not os.path.isdir(repo_config['path']):
-                    print "Unable to clone repository %s" % repo_config['url']
+                    print "Unable to clone %s branch of repository %s" % (repo_config['branch'] if 'branch' in repo_config else "default", repo_config['url'])
                     sys.exit(2)
 
                 else:

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -438,7 +438,10 @@ class GitAutoDeploy(object):
             if not os.path.isdir(repo_config['path']):
 
                 print "Directory %s not found" % repo_config['path']
-                GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
+                if 'branch' in repo_config:
+                    GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
+                else:
+                    GitWrapper.clone(url=repo_config['url'], branch=None, path=repo_config['path'])
 
                 if not os.path.isdir(repo_config['path']):
                     print "Unable to clone repository %s" % repo_config['url']

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -80,10 +80,13 @@ class GitWrapper():
         return int(res)
 
     @staticmethod
-    def clone(url, path):
+    def clone(url, branch, path):
         from subprocess import call
 
-        call(['git clone --recursive %s %s' % (url, path)], shell=True)
+        if branch:
+            call(['git clone --recursive %s -b %s %s' % (url, branch, path)], shell=True)
+        else:
+            call(['git clone --recursive %s %s' % (url, path)], shell=True)
 
 
     @staticmethod
@@ -435,7 +438,7 @@ class GitAutoDeploy(object):
             if not os.path.isdir(repo_config['path']):
 
                 print "Directory %s not found" % repo_config['path']
-                GitWrapper.clone(url=repo_config['url'], path=repo_config['path'])
+                GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
 
                 if not os.path.isdir(repo_config['path']):
                     print "Unable to clone repository %s" % repo_config['url']


### PR DESCRIPTION
Even if the config file defines a specific branch for a repository, the initial clone operation ignores this. Even though this will be corrected by the first pull request, the target repository will be in a unexpected state until then.

This pull request fixes this by adding the branch defined in the config file to the clone command line.