### PR TITLE
Add gitlab example with git over ssh url

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -20,6 +20,10 @@
       "path": "~/repositories/gitignore"
     },
     {
+      "url": "git@gitlab.com:gitlab-org/gitlab-ce.git",
+      "path": "~/repositories/gitignore"
+    },
+    {
       "url": "https://api.github.com/repos/olipo186/Git-Auto-Deploy",
       "deploy": "echo deploying after pull request",
       "filters": [


### PR DESCRIPTION
Signed-off-by: Anton Glukhov <anton.a.glukhov@gmail.com>

I was confused about how to add repository which works with git over ssh proto. I saw issue [#86](https://github.com/olipo186/Git-Auto-Deploy/issues/86) with exactly the same misunderstanding as well. So, here is a little clarity for this case.