### PR TITLE
Windows compatibility

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,7 +46,7 @@ Repository configurations are comprised of the following elements:
  - **filters**: Filters to apply to the web hook events so that only the desired
    events result in executing the deploy actions. See section *Filters* for more
    details.
- - **secret-token**: The secret token set for your webhook ([currently only implemented for GitHub](https://developer.github.com/webhooks/securing/))
+ - **secret-token**: The secret token set for your webhook (currently only implemented for [GitHub](https://developer.github.com/webhooks/securing/) and GitLab)
 
 ## Filters
 *(Currently only supported for GitHub and GitLab)*

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -160,9 +160,9 @@ class GitAutoDeploy(object):
             logger.warning('No process is currently using port %s.' % self._config['port'])
             return False
 
-        if hasattr(signal, SIGKILL):
+        if hasattr(signal, 'SIGKILL'):
             os.kill(pid, signal.SIGKILL)
-        elif hasattr(signal, SIGHUP):
+        elif hasattr(signal, 'SIGHUP'):
             os.kill(pid, signal.SIGHUP)
         else:
             os.kill(pid, 1)
@@ -416,13 +416,13 @@ def main():
 
     app = GitAutoDeploy()
 
-    if hasattr(signal, SIGHUP):
+    if hasattr(signal, 'SIGHUP'):
         signal.signal(signal.SIGHUP, app.signal_handler)
-    if hasattr(signal, SIGINT):
+    if hasattr(signal, 'SIGINT'):
         signal.signal(signal.SIGINT, app.signal_handler)
-    if hasattr(signal, SIGABRT):
+    if hasattr(signal, 'SIGABRT'):
         signal.signal(signal.SIGABRT, app.signal_handler)
-    if hasattr(signal, SIGPIPE) and hasattr(signal, SIG_IGN):
+    if hasattr(signal, 'SIGPIPE') and hasattr(signal, 'SIG_IGN'):
         signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
     config = get_config_defaults()

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -160,7 +160,13 @@ class GitAutoDeploy(object):
             logger.warning('No process is currently using port %s.' % self._config['port'])
             return False
 
-        os.kill(pid, signal.SIGKILL)
+        if hasattr(signal, SIGKILL):
+            os.kill(pid, signal.SIGKILL)
+        elif hasattr(signal, SIGHUP):
+            os.kill(pid, signal.SIGHUP)
+        else:
+            os.kill(pid, 1)
+
         return True
 
     def create_pid_file(self):
@@ -410,10 +416,14 @@ def main():
 
     app = GitAutoDeploy()
 
-    signal.signal(signal.SIGHUP, app.signal_handler)
-    signal.signal(signal.SIGINT, app.signal_handler)
-    signal.signal(signal.SIGABRT, app.signal_handler)
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    if hasattr(signal, SIGHUP):
+        signal.signal(signal.SIGHUP, app.signal_handler)
+    if hasattr(signal, SIGINT):
+        signal.signal(signal.SIGINT, app.signal_handler)
+    if hasattr(signal, SIGABRT):
+        signal.signal(signal.SIGABRT, app.signal_handler)
+    if hasattr(signal, SIGPIPE) and hasattr(signal, SIG_IGN):
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
     config = get_config_defaults()
 

--- a/gitautodeploy/lock.py
+++ b/gitautodeploy/lock.py
@@ -1,12 +1,15 @@
+from lockfile import LockFile
+
 class Lock():
     """Simple implementation of a mutex lock using the file systems. Works on
     *nix systems."""
 
     path = None
-    _has_lock = False
+    lock = None
 
     def __init__(self, path):
         self.path = path
+        self.lock = LockFile(path)
 
     def obtain(self):
         import os
@@ -14,39 +17,31 @@ class Lock():
         logger = logging.getLogger()
 
         try:
-            os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            self._has_lock = True
+            self.lock.acquire(0)
             logger.debug("Successfully obtained lock: %s" % self.path)
-        except OSError:
+        except AlreadyLocked:
             return False
-        else:
-            return True
+
+        return True
 
     def release(self):
         import os
         import logging
         logger = logging.getLogger()
 
-        if not self._has_lock:
+        if not self.has_lock():
             raise Exception("Unable to release lock that is owned by another process")
-        try:
-            os.remove(self.path)
-            logger.debug("Successfully released lock: %s" % self.path)
-        finally:
-            self._has_lock = False
+
+        self.lock.release()
+        logger.debug("Successfully released lock: %s" % self.path)
 
     def has_lock(self):
-        return self._has_lock
+        return self.lock.i_am_locking()
 
     def clear(self):
         import os
         import logging
         logger = logging.getLogger()
 
-        try:
-            os.remove(self.path)
-        except OSError:
-            pass
-        finally:
-            logger.debug("Successfully cleared lock: %s" % self.path)
-            self._has_lock = False
+        self.lock.break_lock()
+        logger.debug("Successfully cleared lock: %s" % self.path)

--- a/gitautodeploy/wrappers/git.py
+++ b/gitautodeploy/wrappers/git.py
@@ -20,11 +20,20 @@ class GitWrapper():
             logger.info('No local repository path configured, no pull will occure')
             return 0
 
-        cmd =   'unset GIT_DIR ' + \
-                '&& git fetch ' + repo_config['remote'] + \
-                '&& git reset --hard ' + repo_config['remote'] + '/' + repo_config['branch'] + ' ' + \
-                '&& git submodule init ' + \
-                '&& git submodule update'
+        import platform
+
+        if platform.system().lower() == "windows":
+            # This assumes Git for Windows is installed.
+            cmd =  ['"\Program Files\Git\usr\\bin\\bash.exe"',
+                    ' -c "cd ' + repo_config['path'],
+                    ' && unset GIT_DIR ']
+        else:
+            cmd =  ['unset GIT_DIR ']
+
+        cmd.append(' && git fetch ' + repo_config['remote'])
+        cmd.append(' && git reset --hard ' + repo_config['remote'] + '/' + repo_config['branch'])
+        cmd.append(' && git submodule init ')
+        cmd.append(' && git submodule update')
 
         # '&& git update-index --refresh ' +\
         res = ProcessWrapper().call([cmd], cwd=repo_config['path'], shell=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 setuptools>=20.3.1
+lockfile>=0.12.2


### PR DESCRIPTION
This introduces Windows compatibility and allows Git-Auto-Deploy to run on Windows.

Has been tested on Windows 2008 R2 with Python 2.7 and MINGW64 from Git for Windows using bash.exe. This setup is the default configuration when installing [Git for Windows](https://git-scm.com/download/win).

Does not work with Python 3.5, but that is not due to this PR.

Windows compatibility fixes:

- Windows does not use signals like *nix does, but the Python [signal](https://docs.python.org/2/library/signal.html) module emulates some of them for convenience. ["On Windows, signal() can only be called with SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, or SIGTERM. A ValueError will be raised in any other case."](https://docs.python.org/3/library/signal.html#signal.signal) A check has been implemented to see if each signal exists before binding a handler to it.
- The included `lock.py` functionality does not work well on Windows and throws `WindowsError: [Error 32] The process cannot access the file because it is being used by another process: <lock file path>` for some unknown reason. The functionality in `lock.py` has been replaced with functionality from the Python module [lockfile](https://pythonhosted.org/lockfile/lockfile.html), which is inherently cross platform. The `requirements.txt` has been updated to reflect this new dependency.
- Calling git commands and bash builtins such as `unset` does not work on Windows, so a check has been implemented which relies on the Python module [platform](https://docs.python.org/2/library/platform.html). If the platform is Windows, the git command chain is prepended with a call to `bash -c "cd repo_config['path'] &&` ensuring the rest of the commands execute in an environment they expect. With this change, the `cmd` string was changed to be a list, which `subprocess` happily accepts. The list is slightly easier to manage than a concatenated string, but more importantly, it seems to work on Windows while the string fails.

I don't expect to have to support this (or any Python) on Windows going forward, but I recently had to use this project on the aforementioned 2008 R2 host and hope my changes would help someone else in a similar position.

PS. I snuck in an update to the configuration documentation mentioning how GitLab.com now supports secret keys for Webhooks, whereas only GitHub supported it before. There is no indication of this functionality in GitLab's docs, but sure enough the option is there and I'm using it successfully.