### PR TITLE
Recursive submodules

### DIFF
--- a/gitautodeploy/wrappers/git.py
+++ b/gitautodeploy/wrappers/git.py
@@ -32,9 +32,7 @@ class GitWrapper():
 
         commands.append('git fetch ' + repo_config['remote'])
         commands.append('git reset --hard ' + repo_config['remote'] + '/' + repo_config['branch'])
-        commands.append('git submodule init')
-        commands.append('git submodule update')
-        commands.append('git submodule foreach --recursive "git submodule init && git submodule update')
+        commands.append('git submodule update --init --recursive')
         #commands.append('git update-index --refresh')
 
         # All commands needs to success

--- a/gitautodeploy/wrappers/git.py
+++ b/gitautodeploy/wrappers/git.py
@@ -34,6 +34,7 @@ class GitWrapper():
         commands.append('git reset --hard ' + repo_config['remote'] + '/' + repo_config['branch'])
         commands.append('git submodule init')
         commands.append('git submodule update')
+        commands.append('git submodule foreach --recursive "git submodule init && git submodule update')
         #commands.append('git update-index --refresh')
 
         # All commands needs to success


### PR DESCRIPTION
Right now only direct submodules inside the repo are updated - any submodules inside these direct submodules are ignored. This PR adds support for recursive submodules, which means that submodules inside submodules are updated as well. This is done by using the `--recursive` option of git's `submodule update` command, so the code changes are very small.

Apart from that the new submodule handling also uses the `--init` option to initialize updated submodules on the fly, so the `git submodule init` call can be removed completely, which makes the code required to update submoduels even smaller than the code of the current version.