### PR TITLE
Fix joined command and options

### DIFF
--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -4,5 +4,5 @@ if __name__ == '__main__':
     import sys
     import os
     import gitautodeploy
-    sys.stderr.write("\033[1;33m[WARNING]\033[0;33m GitAutoDeploy.py is deprecated. Please use \033[1;33m'python gitautodeploy%s'\033[0;33m instead.\033[0m\n" % (' ' + ' '.join(sys.argv[1:])).strip())
+    sys.stderr.write("\033[1;33m[WARNING]\033[0;33m GitAutoDeploy.py is deprecated. Please use \033[1;33m'python gitautodeploy%s'\033[0;33m instead.\033[0m\n" % (' ' + ' '.join(sys.argv[1:])).rstrip())
     gitautodeploy.main()


### PR DESCRIPTION
Before:

```console
$ python GitAutoDeploy.py --daemon-mode
[WARNING] GitAutoDeploy.py is deprecated. Please use 'python gitautodeploy--daemon-mode' instead.
```

Now:

```console
$ python GitAutoDeploy.py --daemon-mode
[WARNING] GitAutoDeploy.py is deprecated. Please use 'python gitautodeploy --daemon-mode' instead.
```

The command and the option were joined instead of space-separated. The `split()` was removing the leading space.