### PR TITLE
Update remote-url and branch when changed in config

### DIFF
--- a/gitautodeploy/cli/config.py
+++ b/gitautodeploy/cli/config.py
@@ -246,6 +246,16 @@ def init_config(config):
 
     for repo_config in config['repositories']:
 
+        # Only clone repositories with a configured path
+        if 'url' not in repo_config:
+            logger.critical("Repository has no configured URL")
+            return 1
+
+        # Only clone repositories with a configured path
+        if 'path' not in repo_config:
+            logger.critical("Repository has no configured path")
+            return 2
+
         # Setup branch if missing
         if 'branch' not in repo_config:
             repo_config['branch'] = "master"
@@ -301,7 +311,7 @@ def init_config(config):
 
                 filter['pull_request'] = True
 
-    return config
+    return 0
 
 def get_repo_config_from_environment():
     """Look for repository config in any defined environment variables. If

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -98,12 +98,8 @@ class GitAutoDeploy(object):
         for repo_config in self._config['repositories']:
 
             if os.path.isdir(repo_config['path']) and os.path.isdir(repo_config['path']+'/.git'):
-                # Pull repository
-                logger.debug("Repository %s already present and will be updated" % repo_config['url'])
-                GitWrapper.pull(repo_config)
+                GitWrapper.init(repo_config)
             else:
-                # Clone repository
-                logger.info("Repository %s not present and needs to be cloned" % repo_config['url'])
                 GitWrapper.clone(repo_config)
 
     def ssh_key_scan(self):

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -97,18 +97,6 @@ class GitAutoDeploy(object):
         # Iterate over all configured repositories
         for repo_config in self._config['repositories']:
 
-            # Only clone repositories with a configured path
-            if 'url' not in repo_config:
-                logger.critical("Repository has no configured URL")
-                self.close()
-                self.exit()
-                return
-
-            # Only clone repositories with a configured path
-            if 'path' not in repo_config:
-                logger.debug("Repository %s will not be cloned (no path configured)" % repo_config['url'])
-                continue
-
             if os.path.isdir(repo_config['path']) and os.path.isdir(repo_config['path']+'/.git'):
                 # Pull repository
                 logger.debug("Repository %s already present and will be updated" % repo_config['url'])
@@ -460,7 +448,10 @@ def main():
         config['repositories'].append(repo_config)
 
     # Initialize config by expanding with missing values
-    init_config(config)
+    if init_config(config) != 0:
+        app.close()
+        app.exit()
+        return
 
     app.setup(config)
     app.serve_forever()

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -110,18 +110,21 @@ class GitAutoDeploy(object):
                 continue
 
             if os.path.isdir(repo_config['path']) and os.path.isdir(repo_config['path']+'/.git'):
-                logger.debug("Repository %s already present" % repo_config['url'])
-                continue
-
-            logger.info("Repository %s not present and needs to be cloned" % repo_config['url'])
-
-            # Clone repository
-            ret = GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
-
-            if ret == 0 and os.path.isdir(repo_config['path']):
-                logger.info("Repository %s successfully cloned" % repo_config['url'])
+                # Pull repository
+                logger.debug("Repository %s already present and will be updated" % repo_config['url'])
+                ret = GitWrapper.pull(repo_config)
+                if ret == 0:
+                    logger.info("Repository %s successfully pulled" % repo_config['url'])
+                else:
+                    logger.error("Unable to pull %s branch of repository %s" % (repo_config['branch'], repo_config['url']))
             else:
-                logger.error("Unable to clone %s branch of repository %s" % (repo_config['branch'], repo_config['url']))
+                # Clone repository
+                logger.info("Repository %s not present and needs to be cloned" % repo_config['url'])
+                ret = GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
+                if ret == 0 and os.path.isdir(repo_config['path']):
+                    logger.info("Repository %s successfully cloned" % repo_config['url'])
+                else:
+                    logger.error("Unable to clone %s branch of repository %s" % (repo_config['branch'], repo_config['url']))
 
     def ssh_key_scan(self):
         import re

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -116,11 +116,7 @@ class GitAutoDeploy(object):
             else:
                 # Clone repository
                 logger.info("Repository %s not present and needs to be cloned" % repo_config['url'])
-                ret = GitWrapper.clone(url=repo_config['url'], branch=repo_config['branch'], path=repo_config['path'])
-                if ret == 0 and os.path.isdir(repo_config['path']):
-                    logger.info("Repository %s successfully cloned" % repo_config['url'])
-                else:
-                    logger.error("Unable to clone %s branch of repository %s" % (repo_config['branch'], repo_config['url']))
+                GitWrapper.clone(repo_config)
 
     def ssh_key_scan(self):
         import re

--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -112,11 +112,7 @@ class GitAutoDeploy(object):
             if os.path.isdir(repo_config['path']) and os.path.isdir(repo_config['path']+'/.git'):
                 # Pull repository
                 logger.debug("Repository %s already present and will be updated" % repo_config['url'])
-                ret = GitWrapper.pull(repo_config)
-                if ret == 0:
-                    logger.info("Repository %s successfully pulled" % repo_config['url'])
-                else:
-                    logger.error("Unable to pull %s branch of repository %s" % (repo_config['branch'], repo_config['url']))
+                GitWrapper.pull(repo_config)
             else:
                 # Clone repository
                 logger.info("Repository %s not present and needs to be cloned" % repo_config['url'])

--- a/gitautodeploy/wrappers/git.py
+++ b/gitautodeploy/wrappers/git.py
@@ -30,8 +30,7 @@ class GitWrapper():
         else:
             commands.append('unset GIT_DIR')
 
-        commands.append('git fetch ' + repo_config['remote'])
-        commands.append('git reset --hard ' + repo_config['remote'] + '/' + repo_config['branch'])
+        commands.append('git checkout -f -B ' + repo_config['branch'] + ' -t ' + repo_config['remote'] + '/' + repo_config['branch'])
         commands.append('git submodule update --init --recursive')
         #commands.append('git update-index --refresh')
 

--- a/gitautodeploy/wrappers/git.py
+++ b/gitautodeploy/wrappers/git.py
@@ -16,11 +16,6 @@ class GitWrapper():
         logger = logging.getLogger()
         logger.info("Updating repository %s" % repo_config['path'])
 
-        # Only pull if there is actually a local copy of the repository
-        if 'path' not in repo_config:
-            logger.info('No local repository path configured, no pull will occure')
-            return 0
-
         commands = []
 
         # On Windows, bash command needs to be run using bash.exe. This assumes bash.exe
@@ -58,11 +53,6 @@ class GitWrapper():
 
         logger = logging.getLogger()
         logger.info("Cloning repository %s" % repo_config['path'])
-
-        # Only pull if there is actually a local copy of the repository
-        if 'path' not in repo_config:
-            logger.info('No local repository path configured, no clone will occure')
-            return 0
 
         commands = []
         commands.append('unset GIT_DIR')


### PR DESCRIPTION
Right now existing repositories are not updated, when Git-Auto-Deploy is started. This causes repos to be out of sync, if GAD crashed and new commits have been pushed to the origin repo during the off-time. Also the branch and remote-url of the repo won't be updated if they have been changed in the config. This PR fixes this by initializing all existing repos when GAD starts.

Apart from that this PR does some minimal refactoring by moving the `repo_config` checks into the config module and enhancing the `clone` method of the git wrapper.