### PR TITLE
Default value detailed-response should be False

### DIFF
--- a/gitautodeploy/cli/config.py
+++ b/gitautodeploy/cli/config.py
@@ -21,7 +21,7 @@ def get_config_defaults():
     # Include details with deploy command return codes in HTTP response. Causes
     # to await any git pull or deploy command actions before it sends the
     # response.
-    config['detailed-response'] = True
+    config['detailed-response'] = False
 
     # Log incoming webhook requests in a way they can be used as test cases
     config['log-test-case'] = False


### PR DESCRIPTION
It was so hard to realize why auto-deploy works again and again until I read Gitlab WebHook documantation tips: 
"Your endpoint should send its HTTP response as fast as possible." and find this config here. 

Gitlab WebHook documantation :
https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md
