### PR TITLE
Allow more than one GitHub repo from the same user (also possible fix for issue 141)

### DIFF
--- a/gitautodeploy/parsers/common.py
+++ b/gitautodeploy/parsers/common.py
@@ -16,7 +16,7 @@ class WebhookRequestParser(object):
             for repo_config in self._config['repositories']:
                 if repo_config in configs:
                     continue
-                if repo_config['url'] == url:
+                if repo_config.get('repo', repo_config.get('url')) == url:
                     configs.append(repo_config)
                 elif 'url_without_usernme' in repo_config and repo_config['url_without_usernme'] == url:
                     configs.append(repo_config)


### PR DESCRIPTION
GitHub does not allow the same SSH key to be used for multiple
repositories on the same server belonging to the same user, see:

http://snipe.net/2013/04/multiple-github-deploy-keys-single-server

The fix there doesn't work because the "url" field is used both to
get the repo and to identify it when a push comes in.  Using a local
SSH name for the repo works for getting the repo but then the name in
the push doesn't match.

This patch adds a 'repo' option that that can be set to the name of
the repo as given in the push.  If 'repo' is not set the behaviour
is unchanged.

Example:

"url": "git@repo-a-shortname/somerepo.git"
"repo": "git@github.com/somerepo.git"