### PR TITLE
Fix pidfile handling in Debian packaging

### DIFF
--- a/platforms/debian/stdeb/git-auto-deploy.init
+++ b/platforms/debian/stdeb/git-auto-deploy.init
@@ -18,7 +18,7 @@ DAEMON=$(which $NAME)
 DAEMON_UID="git-auto-deploy"
 DAEMON_GID="git-auto-deploy"
 RUNDIR=/var/run/$NAME
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=$RUNDIR/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 #PWD=/opt/Git-Auto-Deploy/
 OPTIONS="--daemon-mode --pid-file $PIDFILE --log-file $LOGFILE --config /etc/$NAME.conf.json"
@@ -64,7 +64,7 @@ do_start()
 		mkdir $RUNDIR
 	fi
 	
-	if ! dpkg-statoverride --list $dir >/dev/null 2>&1; then
+	if ! dpkg-statoverride --list $RUNDIR >/dev/null 2>&1; then
 		chown $DAEMON_UID:$DAEMON_GID $RUNDIR
 		chmod g-w,o-rwx $RUNDIR
 	fi

--- a/platforms/debian/stdeb/git-auto-deploy.postinst
+++ b/platforms/debian/stdeb/git-auto-deploy.postinst
@@ -6,7 +6,7 @@ GAD_GID="git-auto-deploy"
 
 HOME_DIR="/etc/$NAME"
 DATA_DIR="/var/lib/$NAME"
-PID_DIR="/var/run/$NAME
+PID_DIR="/var/run/$NAME"
 PID_FILE="$PID_DIR/$NAME.pid"
 
 # Add user and group

--- a/platforms/debian/stdeb/git-auto-deploy.postinst
+++ b/platforms/debian/stdeb/git-auto-deploy.postinst
@@ -6,7 +6,8 @@ GAD_GID="git-auto-deploy"
 
 HOME_DIR="/etc/$NAME"
 DATA_DIR="/var/lib/$NAME"
-PID_FILE="/var/run/$NAME.pid"
+PID_DIR="/var/run/$NAME
+PID_FILE="$PID_DIR/$NAME.pid"
 
 # Add user and group
 adduser --quiet --system --home $HOME_DIR --no-create-home --ingroup nogroup --disabled-password $GAD_UID
@@ -31,8 +32,9 @@ chown -R $GAD_UID:$GAD_GID $DATA_DIR
 chmod 750 $DATA_DIR
 
 # Create pid file
+mkdir $PID_DIR
 touch $PID_FILE
-chown $GAD_UID:$GAD_GID $PID_FILE
+chown $GAD_UID:$GAD_GID $PID_DIR $PID_FILE
 chmod 750 $PID_FILE
 
 update-rc.d $NAME defaults


### PR DESCRIPTION
This patch makes the pidfile be in /var/run/git-auto-deploy instead of /var/run so there are no permission problems.

Regards,

Henk