### PR TITLE
Correct url retrieval, fixes #142

### DIFF
--- a/gitautodeploy/parsers/gitlab.py
+++ b/gitautodeploy/parsers/gitlab.py
@@ -78,8 +78,10 @@ class GitLabCIRequestParser(WebhookRequestParser):
         # Only add repositories if the build is successful. Ignore it in other case.
         if data['build_status'] == "success":
             for k in ['url', 'git_http_url', 'git_ssh_url']:
-                if k in data['repository']:
-                    repo_urls.append(data['repository'][k])
+                for n in ['repository', 'project']:
+                    if n in data:
+                        if k in data[n]:
+                            repo_urls.append(data[n][k])
         else:
             logger.warning("Gitlab CI build '%d' has status '%s'. Not pull will be done" % (
                 data['build_id'], data['build_status']))


### PR DESCRIPTION
As seen here, the `pipeline` webhook is using the `project` key.

https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md

Should fix #142.