### PR TITLE
Added support for Bitbucket Server

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -277,6 +277,55 @@ Execute script upon GitLab CI successful build of `master` branch.
 }
 ```
 
+#### Bitbucket Server
+
+Get source using SSH.
+
+```json
+{
+  "host": "0.0.0.0",
+  "port": 8080,
+  "global_deploy": [
+    "echo Pre-deploy script",
+    "echo Post-deploy script"
+  ],
+  "repositories": [
+    {
+      "url": "ssh://git@bitbucket.example.com/KEY/Git-Auto-Deploy.git",
+      "match-url": "Git-Auto-Deploy",
+      "branch": "master",
+      "remote": "origin",
+      "path": "~/repositories/Git-Auto-Deploy",
+      "deploy": "echo deploying"
+    }
+  ]
+}
+```
+
+Using HTTPS.
+
+```json
+{
+  "host": "0.0.0.0",
+  "port": 8080,
+  "global_deploy": [
+    "echo Pre-deploy script",
+    "echo Post-deploy script"
+  ],
+  "repositories": [
+    {
+      "url": "https://bitbucket.example.com/scm/KEY/Git-Auto-Deploy.git",
+      "match-url": "Git-Auto-Deploy",
+      "branch": "master",
+      "remote": "origin",
+      "path": "~/repositories/Git-Auto-Deploy",
+      "deploy": "echo deploying"
+    }
+  ]
+}
+```
+```
+
 # Repository configuration using environment variables
 
 It's possible to configure up to one repository using environment variables. This can be useful in some specific use cases where a full config file is undesired.

--- a/gitautodeploy/parsers/bitbucket.py
+++ b/gitautodeploy/parsers/bitbucket.py
@@ -28,6 +28,16 @@ class BitBucketRequestParser(WebhookRequestParserBase):
             # needed since the configured repositories might be configured using a different username.
             repo_urls.append('https://bitbucket.org/%s.git' % (data['repository']['full_name']))
 
+        if 'fullName' in data['repository']:
+            # For Bitbucket Server add repository name (OWNER/REPO_NAME).
+            # Support "Post Webhooks for Bitbucket".
+            repo_urls.append(data['repository']['fullName'])
+
+        if 'slug' in data['repository']:
+            # For Bitbucket Server add repository slug.
+            # Support "Post-Receive WebHooks" and "Post Webhooks for Bitbucket".
+            repo_urls.append(data['repository']['slug'])
+
         # Get a list of configured repositories that matches the incoming web hook reqeust
         repo_configs = self.get_matching_repo_configs(repo_urls, action)
 

--- a/test/samples/bitbucket-server-pr-created-filter.negative.test-case.json
+++ b/test/samples/bitbucket-server-pr-created-filter.negative.test-case.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "branch": "master",
+    "deploy": "echo test!",
+    "remote": "origin",
+    "url": "https://bitbucket.example.com/scm/PROJ_KEY/test-hook.git",
+    "match-url": "PROJ_KEY/test-hook",
+    "header-filter": {
+      "x-event-key": "pullrequest:merged"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "data": []
+  },
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "connection": "keep-alive",
+    "content-length": "4248",
+    "content-type": "application/json",
+    "host": "narpau.se:8001",
+    "user-agent": "Bitbucket-Webhooks/2.0",
+    "x-attempt-number": "1",
+    "x-event-key": "pullrequest:created",
+    "x-hook-uuid": "1f813038-7b26-4d08-9b80-ee76eeb53d93",
+    "x-request-uuid": "2e6626d9-effe-46f7-8bfd-e9dee9a58920"
+  },
+  "payload": {
+    "actor": {
+      "username": "username",
+      "displayName": "User Name"
+    },
+    "pullrequest": {
+      "id": "1",
+      "title": "Pull request title",
+      "link": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/pull-requests/1",
+      "authorLogin": "User Name",
+      "fromRef": {
+        "repository": {
+          "scmId": "git",
+          "project": {
+            "key": "PROJ_KEY",
+            "name": "Project Key"
+          },
+          "slug": "test-hook",
+          "links": {
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+              }
+            ]
+          },
+          "public": false,
+          "owner": {
+            "username": "PROJ_KEY",
+            "displayName": "PROJ_KEY"
+          },
+          "fullName": "PROJ_KEY/test-hook",
+          "ownerName": "PROJ_KEY"
+        },
+        "branch": {
+          "name": "test",
+          "rawNode": "4f430da32d7bea2ea13fb8e564267758bce84801"
+        },
+        "commit": {
+          "message": null,
+          "date": null,
+          "hash": "4f430da32d7bea2ea13fb8e564267758bce84801",
+          "authorTimestamp": 0
+        }
+      },
+      "toRef": {
+        "repository": {
+          "scmId": "git",
+          "project": {
+            "key": "PROJ_KEY",
+            "name": "Project Key"
+          },
+          "slug": "test-hook",
+          "links": {
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+              }
+            ]
+          },
+          "public": false,
+          "owner": {
+            "username": "PROJ_KEY",
+            "displayName": "PROJ_KEY"
+          },
+          "fullName": "PROJ_KEY/test-hook",
+          "ownerName": "PROJ_KEY"
+        },
+        "branch": {
+          "name": "develop",
+          "rawNode": "82f42b549b35a42626df183003f84db6d896209d"
+        },
+        "commit": {
+          "message": null,
+          "date": null,
+          "hash": "82f42b549b35a42626df183003f84db6d896209d",
+          "authorTimestamp": 0
+        }
+      }
+    },
+    "repository": {
+      "scmId": "git",
+      "project": {
+        "key": "PROJ_KEY",
+        "name": "Project Key"
+      },
+      "slug": "test-hook",
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+          }
+        ]
+      },
+      "public": false,
+      "owner": {
+        "username": "PROJ_KEY",
+        "displayName": "PROJ_KEY"
+      },
+      "fullName": "PROJ_KEY/test-hook",
+      "ownerName": "PROJ_KEY"
+    }
+  }
+}

--- a/test/samples/bitbucket-server-pr-created-filter.positive.test-case.json
+++ b/test/samples/bitbucket-server-pr-created-filter.positive.test-case.json
@@ -1,0 +1,135 @@
+{
+  "config": {
+    "branch": "master",
+    "deploy": "echo test!",
+    "remote": "origin",
+    "url": "https://bitbucket.example.com/scm/PROJ_KEY/test-hook.git",
+    "match-url": "PROJ_KEY/test-hook",
+    "header-filter": {
+      "x-event-key": "pullrequest:created"
+    }
+  },
+  "expected": {
+    "status": 200,
+    "data": [
+      {
+        "deploy": 0
+      }
+    ]
+  },
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "connection": "keep-alive",
+    "content-length": "4248",
+    "content-type": "application/json",
+    "host": "narpau.se:8001",
+    "user-agent": "Bitbucket-Webhooks/2.0",
+    "x-attempt-number": "1",
+    "x-event-key": "pullrequest:created",
+    "x-hook-uuid": "1f813038-7b26-4d08-9b80-ee76eeb53d93",
+    "x-request-uuid": "2e6626d9-effe-46f7-8bfd-e9dee9a58920"
+  },
+  "payload": {
+    "actor": {
+      "username": "username",
+      "displayName": "User Name"
+    },
+    "pullrequest": {
+      "id": "1",
+      "title": "Pull request title",
+      "link": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/pull-requests/1",
+      "authorLogin": "User Name",
+      "fromRef": {
+        "repository": {
+          "scmId": "git",
+          "project": {
+            "key": "PROJ_KEY",
+            "name": "Project Key"
+          },
+          "slug": "test-hook",
+          "links": {
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+              }
+            ]
+          },
+          "public": false,
+          "owner": {
+            "username": "PROJ_KEY",
+            "displayName": "PROJ_KEY"
+          },
+          "fullName": "PROJ_KEY/test-hook",
+          "ownerName": "PROJ_KEY"
+        },
+        "branch": {
+          "name": "test",
+          "rawNode": "4f430da32d7bea2ea13fb8e564267758bce84801"
+        },
+        "commit": {
+          "message": null,
+          "date": null,
+          "hash": "4f430da32d7bea2ea13fb8e564267758bce84801",
+          "authorTimestamp": 0
+        }
+      },
+      "toRef": {
+        "repository": {
+          "scmId": "git",
+          "project": {
+            "key": "PROJ_KEY",
+            "name": "Project Key"
+          },
+          "slug": "test-hook",
+          "links": {
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+              }
+            ]
+          },
+          "public": false,
+          "owner": {
+            "username": "PROJ_KEY",
+            "displayName": "PROJ_KEY"
+          },
+          "fullName": "PROJ_KEY/test-hook",
+          "ownerName": "PROJ_KEY"
+        },
+        "branch": {
+          "name": "develop",
+          "rawNode": "82f42b549b35a42626df183003f84db6d896209d"
+        },
+        "commit": {
+          "message": null,
+          "date": null,
+          "hash": "82f42b549b35a42626df183003f84db6d896209d",
+          "authorTimestamp": 0
+        }
+      }
+    },
+    "repository": {
+      "scmId": "git",
+      "project": {
+        "key": "PROJ_KEY",
+        "name": "Project Key"
+      },
+      "slug": "test-hook",
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket.example.com/projects/PROJ_KEY/repos/test-hook/browse"
+          }
+        ]
+      },
+      "public": false,
+      "owner": {
+        "username": "PROJ_KEY",
+        "displayName": "PROJ_KEY"
+      },
+      "fullName": "PROJ_KEY/test-hook",
+      "ownerName": "PROJ_KEY"
+    }
+  }
+}


### PR DESCRIPTION
Bitbucket Server is using different payload in the web hooks. Unfortunately, the payload doesn't contain any information about repository URL but it returns repository `slug` and repository `fullName`. Those two values could be used in the `match-url` parameter. This PR adds support for both [Post-Receive WebHooks](https://confluence.atlassian.com/bitbucketserver/post-service-webhook-for-bitbucket-server-776640367.html) and [Post Webhooks for Bitbucket](https://marketplace.atlassian.com/plugins/nl.topicus.bitbucket.bitbucket-webhooks/server/overview).