### PR TITLE
standalone 'web-ui-require-https' check

### DIFF
--- a/gitautodeploy/httpserver.py
+++ b/gitautodeploy/httpserver.py
@@ -280,7 +280,10 @@ def WebhookRequestHandlerFactory(config, event_store, server_status, is_https=Fa
         def validate_web_ui_https(self):
             """Verify that the request is made over HTTPS"""
 
-            if self._is_https and self._config['web-ui-require-https']:
+            if self._is_https:
+                return True
+
+            if not self._config['web-ui-require-https']:
                 return True
 
             # Attempt to redirect the request to HTTPS


### PR DESCRIPTION
I'm running GAD behind a reverse proxy which also handles SSL termination.
I've changed the `validate_web_ui_https` method to return `TRUE` when `config['web-ui-require-https']` is `false`. Now I can access the web ui behind my reverse proxy.

Cheers,
Chris