### PR TITLE
Fix configuration link on gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 cd Git-Auto-Deploy
 </code></pre>
 
-<p>Make a copy of the sample configuration file and modify it to match your project setup. <a href="./docs/Configuration.md">Read more about the configuration options</a>.</p>
+<p>Make a copy of the sample configuration file and modify it to match your project setup. <a href="https://github.com/olipo186/Git-Auto-Deploy/blob/master/docs/Configuration.md">Read more about the configuration options</a>.</p>
 
 <pre><code>cp config.json.sample config.json
 </code></pre>
@@ -80,7 +80,7 @@ sudo apt-get update
 <pre><code>sudo apt-get install git-auto-deploy
 </code></pre>
 
-<p>Modify the configuration file to match your project setup. <a href="./docs/Configuration.md">Read more about the configuration options</a>.</p>
+<p>Modify the configuration file to match your project setup. <a href="https://github.com/olipo186/Git-Auto-Deploy/blob/master/docs/Configuration.md">Read more about the configuration options</a>.</p>
 
 <pre><code>nano /etc/git-auto-deploy.conf.json
 </code></pre>
@@ -103,7 +103,7 @@ service git-auto-deploy status
 <h2>
 <a id="command-line-options" class="anchor" href="#command-line-options" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Command line options</h2>
 
-<p>Below is a summarized list of the most common command line options. For a full list of available command line options, invoke the application with the argument <code>--help</code> or read the documentation article about <a href="./docs/Configuration.md">all available command line options, environment variables and config attributes</a>.</p>
+<p>Below is a summarized list of the most common command line options. For a full list of available command line options, invoke the application with the argument <code>--help</code> or read the documentation article about <a href="https://github.com/olipo186/Git-Auto-Deploy/blob/master/docs/Configuration.md">all available command line options, environment variables and config attributes</a>.</p>
 
 <table>
 <thead>


### PR DESCRIPTION
The web page being displayed through the gh-pages branch has a 404 on configurations.

I think it is due to a change in the directory structure. 