### PR TITLE
Fix Dockerfile. Build and push image to Github packages. Add description and example.

### DIFF
--- a/.github/workflows/create-docker-images.yml
+++ b/.github/workflows/create-docker-images.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Calculate docker image repo
         run: echo ::set-env name=IMAGE_REPO::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+      - name: Calculate docker image tag
+        run: echo ::set-env name=IMAGE_TAG::$(./.github/workflows/docker-tag.sh ${{github.ref}})
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v1
         with:
@@ -44,4 +46,5 @@ jobs:
           registry: docker.pkg.github.com
           repository: ${{env.IMAGE_REPO}}/git-auto-deploy
           dockerfile: docker/image-gitautodeploy/Dockerfile
-          tag_with_ref: true
+          tag_with_ref: false
+          tags: ${{env.IMAGE_TAG}}

--- a/.github/workflows/create-docker-images.yml
+++ b/.github/workflows/create-docker-images.yml
@@ -1,0 +1,47 @@
+name: Test and build
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v0.*
+      - dv0.*
+
+jobs:
+
+  test:
+    name: Testing
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out the repo
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: python test/test_parsers.py
+
+  push_to_registry:
+    name: Push "git-auto-deploy" docker image to GitHub Packages
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Calculate docker image repo
+        run: echo ::set-env name=IMAGE_REPO::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: ${{env.IMAGE_REPO}}/git-auto-deploy
+          dockerfile: docker/image-gitautodeploy/Dockerfile
+          tag_with_ref: true

--- a/.github/workflows/docker-tag.sh
+++ b/.github/workflows/docker-tag.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+REF=$@
+echo $@ | \
+    sed -E 's|^refs/heads/master$|latest|' | \
+    sed -E 's|^refs/pull/(.*)|pr-\1|' | \
+    sed -E 's|^refs/(heads\|tags)/(.*)|\2|' | \
+    sed -E 's|/|-|g'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM google/python-runtime
-
-RUN apt-get update && \
-    apt-get -y install openssh-client
-
-RUN mkdir $HOME/.ssh && chmod 600 $HOME/.ssh
-COPY deploy_rsa /root/.ssh/id_rsa
-
-ENTRYPOINT ["/env/bin/python", "-u", "GitAutoDeploy.py", "--ssh-keyscan"]

--- a/docker/examples/gitautodeploy-base-usage/README.md
+++ b/docker/examples/gitautodeploy-base-usage/README.md
@@ -1,0 +1,21 @@
+# Example of "git-auto-deploy" usage
+
+This is an example of usage of "git-auto-deploy" docker image.
+
+Example docker image extends "git-auto-deploy"
+by adding a non-root user and configuration.
+Also it specifies addition run option `--ssh-keyscan` in CMD that attaches
+to ENTRYPOINT of the parent image. `--ssh-keyscan` isn't actually used but
+it's addef for example only.
+
+## How to run the example
+
+    cd docker/example/gitautodeploy-base-usage/image
+    docker build -t the-example .
+    docker run --init --rm -p 8080:8080 the-example
+
+## Structure
+
+The example consists of `app` and `image` folders.
+`image` is the image context.
+`app` is an app that GAD pulls and deploys

--- a/docker/examples/gitautodeploy-base-usage/app/deploy-app.py
+++ b/docker/examples/gitautodeploy-base-usage/app/deploy-app.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+print('This is a image usage example app.')

--- a/docker/examples/gitautodeploy-base-usage/image/Dockerfile
+++ b/docker/examples/gitautodeploy-base-usage/image/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.pkg.github.com/evoja/docker-git-auto-deploy/git-auto-deploy:dv0.17
+
+ENV GAD_USER=gad GAD_UID=1001
+
+RUN \
+    mkdir -p /home/$GAD_USER && \
+    adduser -s /bin/sh -D -u $GAD_UID $GAD_USER && \
+    mkdir /home/$GAD_USER/.ssh && chmod 500 /home/$GAD_USER/.ssh && \
+    touch /home/$GAD_USER/.ssh/known_hosts && \
+    chmod 600 /home/$GAD_USER/.ssh/known_hosts && \
+    chown -R $GAD_USER:$GAD_USER /home/$GAD_USER && \
+    chown -R $GAD_USER:$GAD_USER /app
+
+USER $GAD_USER
+COPY my.config.json ./config.json
+
+CMD ["--ssh-keyscan"]

--- a/docker/examples/gitautodeploy-base-usage/image/my.config.json
+++ b/docker/examples/gitautodeploy-base-usage/image/my.config.json
@@ -1,0 +1,37 @@
+{
+  "== HTTP server options": "==",
+  "http-enabled": true,
+  "http-host": "0.0.0.0",
+  "http-port": 8080,
+
+  "https-enabled": false,
+  "wss-enabled": false,
+
+  "== Web user interface options": "==",
+  "web-ui-enabled": false,
+
+  "== File to store a copy of the console output": "==",
+  "log-file": "~/gitautodeploy.log",
+
+  "== File to store the process id (pid)": "==",
+  "pid-file": "~/.gitautodeploy.pid",
+
+  "== Record all log levels by default": "==",
+  "log-level": "INFO",
+
+  "== Deploy commands that should be executed for all projects": "==",
+  "global_deploy": [
+    "echo Deploy started!",
+    "echo Deploy completed!"
+  ],
+
+  "repositories": [
+    {
+      "url": "https://github.com/olipo186/Git-Auto-Deploy.git",
+      "branch": "master",
+      "remote": "origin",
+      "path": "~/repositories/git-auto-deploy",
+      "deploy": "./docker/examples/gitautodeploy-base-usage/app/run.py"
+    }
+  ]
+}

--- a/docker/image-gitautodeploy/Dockerfile
+++ b/docker/image-gitautodeploy/Dockerfile
@@ -1,0 +1,24 @@
+# Indifferent base image, just OS and GitAutoDeploy.
+# Consumers should add configs, keys, users etc.
+#
+# People prefer different ways of configuring:
+# volumes, ONBUILD instructions, secrets, configs, evironment vairables.
+# This image doesn't have any proposals to let everyone do what they want.
+FROM alpine:3.12.0
+# Build context is expected to be the root of the git repository Git-Auto-Deploy.
+
+RUN apk --no-cache --update add \
+        python2 ca-certificates git openssh-client \
+        && \
+    python --version && which python && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && pip install --upgrade pip && rm get-pip.py && \
+    rm -rf /var/cache/apk/*
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY gitautodeploy /app/gitautodeploy
+
+WORKDIR /app
+ENTRYPOINT ["/usr/bin/python", "-m", "gitautodeploy"]

--- a/docker/image-gitautodeploy/README.md
+++ b/docker/image-gitautodeploy/README.md
@@ -24,3 +24,5 @@ Possible usage can look like a child image with following Dockerfile:
     COPY config.json .
 
     CMD ["--ssh-keyscan"]
+
+Also you can look at the [example](../examples/gitautodeploy-base-usage)

--- a/docker/image-gitautodeploy/README.md
+++ b/docker/image-gitautodeploy/README.md
@@ -1,0 +1,26 @@
+# Image "git-auto-deploy"
+Indifferent base image, just OS and GitAutoDeploy.
+Consumers should add configs, keys, users etc.
+
+People prefer different ways of configuring:
+volumes, ONBUILD instructions, secrets, configs, evironment vairables.
+This image doesn't have any proposals to let everyone do what they want.
+
+Possible usage can look like a child image with following Dockerfile:
+
+    FROM docker.pkg.github.com/evoja/docker-git-auto-deploy/git-auto-deploy:dv0.17
+
+    ENV GAD_USER=gad GAD_UID=1001
+    RUN \
+        mkdir -p /home/$GAD_USER && \
+        adduser -s /bin/sh -D -u $GAD_UID $GAD_USER && \
+        mkdir /home/$GAD_USER/.ssh && chmod 500 /home/$GAD_USER/.ssh && \
+        touch /home/$GAD_USER/.ssh/known_hosts && \
+        chmod 600 /home/$GAD_USER/.ssh/known_hosts && \
+        chown -R $GAD_USER:$GAD_USER /home/$GAD_USER && \
+        chown -R $GAD_USER:$GAD_USER /app
+
+    USER $GAD_USER
+    COPY config.json .
+
+    CMD ["--ssh-keyscan"]


### PR DESCRIPTION
Hi @olipo186,

I've found that the Dockerfile isn't buildable anymore. It shows me following when I try to build:

    Step 1/5 : FROM google/python-runtime
    pull access denied for google/python-runtime, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

That's why I've fixed the Dockerfile by making it _alpine_ based. Also I've added a description and example. Looks like the PR relates to #93 and #42

Apart from that I add a GitHub Action that builds image and pushes it to Docker packages, so people don't need DockerHub anymore to use GAD as docker image. Package of this repo becomes source of truth.

Feel free to propose cuts of the PR if you don't want something of above to be merged. I'll split changes to several parts and push less to PR.

Cheers!