### PR TITLE
docs: fix simple typo, nessecary -> necessary

### DIFF
--- a/gitautodeploy/gitautodeploy.py
+++ b/gitautodeploy/gitautodeploy.py
@@ -494,7 +494,7 @@ class GitAutoDeploy(object):
             from autobahn.websocket import WebSocketServerProtocol, WebSocketServerFactory
             from twisted.internet import reactor
 
-            # Given that the nessecary dependencies are present, notify the
+            # Given that the necessary dependencies are present, notify the
             # event that we expect the web socket server to be started
             self._startup_event.ws_started = False
         except ImportError:


### PR DESCRIPTION
There is a small typo in gitautodeploy/gitautodeploy.py.

Should read `necessary` rather than `nessecary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md