### PR TITLE
Adding python3 compatibility imports. 

### DIFF
--- a/gitautodeploy/cli/config.py
+++ b/gitautodeploy/cli/config.py
@@ -352,7 +352,11 @@ def init_config(config):
     import os
     import re
     import logging
-    from ..models import Project
+    try:
+        from ..models import Project
+    except ImportError:
+        from gitautodeploy.models import Project
+
     logger = logging.getLogger()
 
     # Translate any ~ in the path into /home/<user>

--- a/gitautodeploy/httpserver.py
+++ b/gitautodeploy/httpserver.py
@@ -94,7 +94,10 @@ def WebhookRequestHandlerFactory(config, event_store, server_status, is_https=Fa
             import logging
             import json
             import threading
-            from urlparse import parse_qs
+            try:
+                from urlparse import parse_qs
+            except ModuleNotFoundError:
+                from urllib.parse import parse_qs
 
             logger = logging.getLogger()
 


### PR DESCRIPTION

This keeps backwards compatibility with Python2 (in case that is still required), but adds minimal changes that are needed to be Python3 compatible. 